### PR TITLE
Adição de badge com total de downloads dos release assets no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ## Links
 
 ### 💻 [Baixar Tradução (Capítulos 1 e 2)](https://github.com/gomaproi/deltarune-ptbr/releases/latest)
+<img src="https://img.shields.io/github/downloads/teiarruma/deltarune-ptbr/total.svg?label=Total%20de%20Downloads" alt="Valor total de downloads dos arquivos anexos às releases deste repositório" title="Contagem desde outubro de 2023" />
 
 **O link te redirecionará à nossa publicação mais recente da tradução dos capítulos 1 e 2.** Quer baixar uma versão mais antiga? Dê uma olhada na nossa [página de publicações](https://github.com/gomaproi/deltarune-ptbr/releases)! Note que os arquivos apenas contém os arquivos da tradução, e não o jogo em si. Você terá que baixar o jogo pela [Steam](https://store.steampowered.com/app/1671210/DELTARUNE/) ou [Itch.io](https://tobyfox.itch.io/deltarune) e substituir os arquivos do jogo.
 


### PR DESCRIPTION
Essa badge proporcionada pelo [Shields.io](https://shields.io/) exibe a soma total do número de downloads de cada asset de cada release deste repositório. Considero que exibir o total de downloads da tradução é uma informação interessante a se ter no documento descritor do repositório.

No entanto, o número aqui apresentado não reflete o total de downloads da tradução do capítulo 2 em 2021 pelo Google Drive divulgado no Twitter e Facebook. A contagem aqui representa o total de downloads feitos aqui no GitHub: o total de downloads da nossa tradução do capítulo 1 de 2018 e o total de downloads desde outubro de 2023 quando nós, Teiarruma, migramos o local de nossa publicação da tradução do Google Drive para o GitHub.